### PR TITLE
[DSNYMANAGE-27] Check model load + trigger asynch retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'eu.xenit.docker-compose' version '5.5.1' apply false
 }
 subprojects {
-    def baseVersion = System.getenv("TAG_VERSION") ?: 'v0.0.7'
+    def baseVersion = System.getenv("TAG_VERSION") ?: 'v0.0.8'
     version = baseVersion[1..baseVersion.length() - 1]
     ext {
         junitJupiterVersion = '5.4.2'

--- a/solr-actuators/src/main/java/eu/xenit/actuators/handler/ReadinessConfig.java
+++ b/solr-actuators/src/main/java/eu/xenit/actuators/handler/ReadinessConfig.java
@@ -3,6 +3,8 @@ package eu.xenit.actuators.handler;
 public class ReadinessConfig {
 
     public static final String READINESS_MAX_LAG = "READINESS_MAX_LAG";
+    public static final String READINESS_MODEL_LOAD_VALIDATION_ENABLED = "READINESS_MODEL_LOAD_VALIDATION_ENABLED";
+    public static final String READINESS_MODEL_LOAD_RETRIGGER_ENABLED = "READINESS_MODEL_LOAD_RETRIGGER_ENABLED";
     public static final String READINESS_TX_LAG_VALIDATION_ENABLED = "READINESS_TX_LAG_VALIDATION_ENABLED";
     public static final String READINESS_CHANGE_SET_LAG_VALIDATION_ENABLED = "READINESS_CHANGE_SET_LAG_VALIDATION_ENABLED";
     public static final String READINESS_REPLICATION_VALIDATION_ENABLED = "READINESS_REPLICATION_VALIDATION_ENABLED";
@@ -12,7 +14,19 @@ public class ReadinessConfig {
     }
 
     private final long maxLag;
+    private final boolean modelLoadValidationEnabled;
+    private final boolean modelLoadRetriggerEnabled;
     private final boolean txValidationEnabled;
+    private final boolean changeSetValidationEnabled;
+    private final boolean replicationValidationEnabled;
+
+    public boolean isModelLoadValidationEnabled() {
+        return modelLoadValidationEnabled;
+    }
+
+    public boolean isModelLoadRetriggerEnabled() {
+        return modelLoadRetriggerEnabled;
+    }
 
     public boolean isTxValidationEnabled() {
         return txValidationEnabled;
@@ -26,11 +40,10 @@ public class ReadinessConfig {
         return replicationValidationEnabled;
     }
 
-    private final boolean changeSetValidationEnabled;
-    private final boolean replicationValidationEnabled;
-
     public ReadinessConfig() {
         maxLag = getLongConfig(READINESS_MAX_LAG, 1800000L);
+        modelLoadValidationEnabled = getBooleanConfig(READINESS_MODEL_LOAD_VALIDATION_ENABLED, true);
+        modelLoadRetriggerEnabled = getBooleanConfig(READINESS_MODEL_LOAD_RETRIGGER_ENABLED, true);
         txValidationEnabled = getBooleanConfig(READINESS_TX_LAG_VALIDATION_ENABLED, true);
         changeSetValidationEnabled = getBooleanConfig(READINESS_CHANGE_SET_LAG_VALIDATION_ENABLED, true);
         replicationValidationEnabled = getBooleanConfig(READINESS_REPLICATION_VALIDATION_ENABLED, true);

--- a/solr-actuators/src/main/java/eu/xenit/actuators/handler/ReadinessHandler.java
+++ b/solr-actuators/src/main/java/eu/xenit/actuators/handler/ReadinessHandler.java
@@ -5,6 +5,7 @@ import org.alfresco.solr.AlfrescoCoreAdminHandler;
 import org.alfresco.solr.TrackerState;
 import org.alfresco.solr.tracker.AclTracker;
 import org.alfresco.solr.tracker.MetadataTracker;
+import org.alfresco.solr.tracker.ModelTracker;
 import org.alfresco.solr.tracker.TrackerRegistry;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
@@ -21,6 +22,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.text.MessageFormat;
 
 public class ReadinessHandler extends RequestHandlerBase implements SolrCoreAware {
@@ -29,7 +33,12 @@ public class ReadinessHandler extends RequestHandlerBase implements SolrCoreAwar
     private static final String DOWN = "DOWN";
     private static final String UP = "UP";
     private static final ReadinessConfig config = new ReadinessConfig();
-    SolrCore core;
+
+    private SolrCore core;
+
+    private AtomicBoolean isModelLoadInProgress = new AtomicBoolean(false);
+
+    private Executor modelLoadExecutor;
 
     @Override
     public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) {
@@ -40,6 +49,8 @@ public class ReadinessHandler extends RequestHandlerBase implements SolrCoreAwar
                     .getCoreContainer()
                     .getMultiCoreHandler();
             boolean setInfo = req.getParams().get("info") != null;
+
+            checkModelResponse(setInfo, rsp, coreAdminHandler.getTrackerRegistry(), solrCore.getName());
 
             checkTransactionResponse(setInfo, rsp, coreAdminHandler.getTrackerRegistry(), solrCore.getName());
 
@@ -60,6 +71,24 @@ public class ReadinessHandler extends RequestHandlerBase implements SolrCoreAwar
             return;
         }
         rsp.add(READY, UP);
+    }
+
+    private void checkModelResponse(boolean setInfo,
+                                          SolrQueryResponse rsp,
+                                          TrackerRegistry trackerRegistry,
+                                          String coreName) {
+        if (!config.isModelLoadValidationEnabled()) return;
+
+        boolean hasModels = trackerRegistry.getModelTracker().hasModels();
+        if (setInfo) {
+            rsp.add("hasModels", hasModels);
+        }
+
+        if (!hasModels) {
+            loadModels(trackerRegistry.getModelTracker());
+            throw new SolrException(SolrException.ErrorCode.SERVICE_UNAVAILABLE,
+                    "Solr did not yet get load dictionary models from alfresco server");
+        }
     }
 
     private void checkTransactionResponse(boolean setInfo,
@@ -122,8 +151,8 @@ public class ReadinessHandler extends RequestHandlerBase implements SolrCoreAwar
         }
         if (changeSetLag >= config.getMaxLag()) {
             throw new SolrException(SolrException.ErrorCode.SERVICE_UNAVAILABLE,
-                    MessageFormat.format("Change set lag is larger than permitted:  changeSetLag={0}, MAX_LAG={1}"
-                            , changeSetLag, config.getMaxLag()));
+                    MessageFormat.format("Change set lag is larger than permitted:  changeSetLag={0}, MAX_LAG={1}",
+                            changeSetLag, config.getMaxLag()));
         }
     }
 
@@ -148,6 +177,26 @@ public class ReadinessHandler extends RequestHandlerBase implements SolrCoreAwar
         } else if ("failed".equals(status)) {
             throw new SolrException(SolrException.ErrorCode.SERVICE_UNAVAILABLE,
                     "Replication handler restore has failed");
+        }
+    }
+
+    private void loadModels(ModelTracker modelTracker)
+    {
+        if (this.isModelLoadInProgress.compareAndSet(false, true)) {
+
+            if (this.modelLoadExecutor == null) {
+                this.modelLoadExecutor = Executors.newFixedThreadPool(1);
+            }
+
+            this.modelLoadExecutor.execute(() -> {
+                try {
+                    if (!modelTracker.hasModels()) {
+                        modelTracker.ensureFirstModelSync();
+                    }
+                } finally {
+                    this.isModelLoadInProgress.compareAndSet(true, false);
+                }
+            });
         }
     }
 

--- a/solr-actuators/src/main/java/eu/xenit/actuators/handler/ReadinessHandler.java
+++ b/solr-actuators/src/main/java/eu/xenit/actuators/handler/ReadinessHandler.java
@@ -84,7 +84,7 @@ public class ReadinessHandler extends RequestHandlerBase implements SolrCoreAwar
             rsp.add("hasModels", hasModels);
         }
 
-        if (!hasModels) {
+        if (!hasModels && config.isModelLoadRetriggerEnabled()) {
             loadModels(trackerRegistry.getModelTracker());
             throw new SolrException(SolrException.ErrorCode.SERVICE_UNAVAILABLE,
                     "Solr did not yet get load dictionary models from alfresco server");


### PR DESCRIPTION
This PR enhances the readiness handler to check whether the models have already been loaded (pre-condition for `MetadataHandler` doing a run), and executing an asynchronous model load to force it (should have been done as part of the startup via the `SolrCoreLoadListener`). This is to deal with a special condition in which ACS unavailability during SOLR startup combined with a large index and suggester build could cause SOLR tracking to be blocked (until suggester build is done). Details are documented in DSNYMANAGE-27